### PR TITLE
ensure joining node can be validated

### DIFF
--- a/examples/demo/src/cli.rs
+++ b/examples/demo/src/cli.rs
@@ -20,7 +20,7 @@ pub fn node_cli() -> Command {
         .disable_help_flag(true)
         .subcommand(
             Command::new("create")
-                .about("Create a new cluster")
+                .about("Create a new named cluster")
                 .arg(
                     clap::Arg::new("name")
                         .long("name")
@@ -57,7 +57,9 @@ pub fn node_cli() -> Command {
                     clap::Arg::new("name")
                         .long("name")
                         .value_name("NAME")
-                        .help("Name of the cluster to start")
+                        .help(
+                            "Name of the existing cluster config to start or skip to use ephemeral cluster",
+                        )
                         .required(false),
                 )
                 .arg(
@@ -67,7 +69,7 @@ pub fn node_cli() -> Command {
                         .value_name("SIZE")
                         .help("Size of the cluster")
                         .conflicts_with("name")
-                        .required(false),
+                        .required_unless_present("name"),
                 )
                 .arg(
                     clap::Arg::new("partition-size")
@@ -76,7 +78,7 @@ pub fn node_cli() -> Command {
                         .value_name("PARTITION_SIZE")
                         .help("Number of partitions")
                         .conflicts_with("name")
-                        .required(false),
+                        .required_unless_present("name"),
                 )
                 .arg(
                     clap::Arg::new("replication-factor")
@@ -85,7 +87,7 @@ pub fn node_cli() -> Command {
                         .value_name("REPLICATION_FACTOR")
                         .help("Replication factor")
                         .conflicts_with("name")
-                        .required(false),
+                        .required_unless_present("name"),
                 )
                 .arg(
                     clap::Arg::new("host")
@@ -117,7 +119,7 @@ pub fn node_cli() -> Command {
                     clap::Arg::new("name")
                         .long("name")
                         .value_name("NAME")
-                        .help("Name of the cluster to join")
+                        .help("Name of the cluster to join or skip to default to ephemeral cluster")
                         .required(false),
                 )
                 .arg(

--- a/gossipgrid/src/cluster/tests.rs
+++ b/gossipgrid/src/cluster/tests.rs
@@ -339,6 +339,7 @@ fn test_next_node() {
         3001,
         None,
         Some(cluster_config),
+        "EPHEMERAL".to_string(),
     );
     match memory {
         NodeState::Joined(ref mut joined) => {
@@ -401,6 +402,7 @@ fn test_next_nodes() {
         3001,
         None,
         Some(cluster_config),
+        "EPHEMERAL".to_string(),
     );
     match memory {
         NodeState::Joined(ref mut joined) => {

--- a/gossipgrid/src/gossip.rs
+++ b/gossipgrid/src/gossip.rs
@@ -73,6 +73,7 @@ pub struct NodeJoinRequest {
     pub node: SimpleNode,
     pub peer_address: String,
     pub node_cluster_metadata: Option<NodeClusterMetadata>,
+    pub cluster_name: String,
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
@@ -191,6 +192,7 @@ async fn send_join_request(
         node: node_state.get_simple_node_as(node::SimpleNodeState::JoinedSyncing),
         peer_address: join_node.as_str().to_string(),
         node_cluster_metadata: cluster_metadata,
+        cluster_name: node_state.cluster_name.clone(),
     });
 
     if let Ok(encoded) = bincode::encode_to_vec(&msg, bincode::config::standard()) {
@@ -308,7 +310,14 @@ async fn handle_join_request(
     let cluster_updated = {
         let mut node_state = state.write().await;
         if let node::NodeState::Joined(this_node) = &mut *node_state {
-            let is_member = this_node.cluster.get_node_index(&message.node.address);
+            if this_node.cluster.cluster_name != message.cluster_name {
+                error!(
+                    "node={}; Rejecting join request from {} due to cluster name mismatch. Expected: {}, Got: {}",
+                    &this_node.address, &message.node.address, this_node.cluster.cluster_name, message.cluster_name
+                );
+                false
+            } else {
+                let is_member = this_node.cluster.get_node_index(&message.node.address);
 
             if let Some(node_id) = is_member {
                 warn!(
@@ -372,6 +381,7 @@ async fn handle_join_request(
                     }
                 }
             }
+           }
         } else {
             error!(
                 "node={}; {}; Cannot handle operation in current state: {}",

--- a/gossipgrid/src/gossip.rs
+++ b/gossipgrid/src/gossip.rs
@@ -311,77 +311,80 @@ async fn handle_join_request(
         let mut node_state = state.write().await;
         if let node::NodeState::Joined(this_node) = &mut *node_state {
             if this_node.cluster.cluster_name != message.cluster_name {
-                error!(
+                warn!(
                     "node={}; Rejecting join request from {} due to cluster name mismatch. Expected: {}, Got: {}",
-                    &this_node.address, &message.node.address, this_node.cluster.cluster_name, message.cluster_name
+                    &this_node.address,
+                    &message.node.address,
+                    this_node.cluster.cluster_name,
+                    message.cluster_name
                 );
                 false
             } else {
                 let is_member = this_node.cluster.get_node_index(&message.node.address);
 
-            if let Some(node_id) = is_member {
-                warn!(
-                    "node={}; Remote node {} is already a known member, but may be re-joining",
-                    &this_node.address, &message.node.address,
-                );
+                if let Some(node_id) = is_member {
+                    warn!(
+                        "node={}; Remote node {} is already a known member, but may be re-joining",
+                        &this_node.address, &message.node.address,
+                    );
 
-                let mut updated_node = message.node.clone();
-                updated_node.last_seen = now_millis();
+                    let mut updated_node = message.node.clone();
+                    updated_node.last_seen = now_millis();
 
-                let changed = this_node
-                    .cluster
-                    .assign_node(&node_id, &updated_node)
-                    .unwrap_or_default();
-                if changed {
-                    this_node.tick_hlc();
-                }
-                true
-            } else if this_node.cluster.is_fully_assigned() {
-                error!("node={}; Cluster is full, cannot join", &this_node.address);
-                false
-            } else {
-                info!(
-                    "node={}; New remote node {:?} joining cluster",
-                    &this_node.address, &message.node
-                );
-                let mut updated_node = message.node.clone();
-                updated_node.last_seen = now_millis();
-
-                if let Some(join_metadata) = message.node_cluster_metadata {
-                    if let Some(partitions) = this_node
+                    let changed = this_node
                         .cluster
-                        .get_assigned_partitions(join_metadata.node_index)
-                        && partitions.iter().map(|x| x.0).collect::<Vec<_>>()
-                            == join_metadata.owned_partitions
-                    {
-                        let changed = this_node
-                            .cluster
-                            .assign_node(&join_metadata.node_index, &updated_node)
-                            .unwrap_or_default();
-                        if changed {
-                            this_node.tick_hlc();
-                        }
-                        true
-                    } else {
-                        error!(
-                            "node={}; Cannot join, metadata provided but not matching node index",
-                            &this_node.address
-                        );
-                        false
+                        .assign_node(&node_id, &updated_node)
+                        .unwrap_or_default();
+                    if changed {
+                        this_node.tick_hlc();
                     }
+                    true
+                } else if this_node.cluster.is_fully_assigned() {
+                    error!("node={}; Cluster is full, cannot join", &this_node.address);
+                    false
                 } else {
-                    // no cluster metadata provided
-                    if let Ok((_idx, changed)) = this_node.cluster.assign_next(&updated_node) {
-                        if changed {
-                            this_node.tick_hlc();
+                    info!(
+                        "node={}; New remote node {:?} joining cluster",
+                        &this_node.address, &message.node
+                    );
+                    let mut updated_node = message.node.clone();
+                    updated_node.last_seen = now_millis();
+
+                    if let Some(join_metadata) = message.node_cluster_metadata {
+                        if let Some(partitions) = this_node
+                            .cluster
+                            .get_assigned_partitions(join_metadata.node_index)
+                            && partitions.iter().map(|x| x.0).collect::<Vec<_>>()
+                                == join_metadata.owned_partitions
+                        {
+                            let changed = this_node
+                                .cluster
+                                .assign_node(&join_metadata.node_index, &updated_node)
+                                .unwrap_or_default();
+                            if changed {
+                                this_node.tick_hlc();
+                            }
+                            true
+                        } else {
+                            error!(
+                                "node={}; Cannot join, metadata provided but not matching node index",
+                                &this_node.address
+                            );
+                            false
                         }
-                        true
                     } else {
-                        false
+                        // no cluster metadata provided
+                        if let Ok((_idx, changed)) = this_node.cluster.assign_next(&updated_node) {
+                            if changed {
+                                this_node.tick_hlc();
+                            }
+                            true
+                        } else {
+                            false
+                        }
                     }
                 }
             }
-           }
         } else {
             error!(
                 "node={}; {}; Cannot handle operation in current state: {}",

--- a/gossipgrid/src/node/builder.rs
+++ b/gossipgrid/src/node/builder.rs
@@ -276,6 +276,7 @@ impl NodeBuilder {
             web_port,
             self.join_peer,
             self.cluster_config,
+            wal_namespace,
         )));
 
         // Load static functions if provided

--- a/gossipgrid/src/node/builder.rs
+++ b/gossipgrid/src/node/builder.rs
@@ -62,7 +62,7 @@ pub struct NodeBuilder {
     store: Option<Box<dyn Store + Send + Sync>>,
     is_ephemeral: bool,
     functions_path: Option<std::path::PathBuf>,
-    cluster_name: Option<String>,
+    join_cluster_name: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -88,7 +88,7 @@ impl NodeBuilder {
             store: None,
             is_ephemeral: false,
             functions_path: None,
-            cluster_name: None,
+            join_cluster_name: None,
         }
     }
 
@@ -133,10 +133,10 @@ impl NodeBuilder {
             })?);
 
         if let Some(name) = name {
-            self.cluster_name = Some(name.to_string());
+            self.join_cluster_name = Some(name.to_string());
             self.is_ephemeral = false;
         } else {
-            self.cluster_name = Some(EPHEMERAL.to_string());
+            self.join_cluster_name = Some(EPHEMERAL.to_string());
             self.is_ephemeral = true;
         }
         Ok(self)
@@ -175,7 +175,6 @@ impl NodeBuilder {
             true, // is_ephemeral
         ));
         self.is_ephemeral = true;
-        self.cluster_name = Some(EPHEMERAL.to_string());
         self
     }
 
@@ -215,10 +214,10 @@ impl NodeBuilder {
         }
 
         // Determine WAL namespace
-        let wal_namespace = if let Some(ref config) = self.cluster_config {
+        let cluster_name = if let Some(ref config) = self.cluster_config {
             config.cluster_name.clone()
         } else {
-            self.cluster_name
+            self.join_cluster_name
                 .clone()
                 .unwrap_or_else(|| EPHEMERAL.to_string())
         };
@@ -226,7 +225,7 @@ impl NodeBuilder {
         // Create WAL
         let wal: Arc<dyn Wal<WalRecord> + Send + Sync> = Arc::new(
             WalLocalFile::new(
-                crate::fs::wal_dir(&wal_namespace),
+                crate::fs::wal_dir(&cluster_name),
                 self.is_ephemeral,
                 5 * 1024 * 1024,
             )
@@ -243,7 +242,7 @@ impl NodeBuilder {
             None => {
                 #[cfg(feature = "sstable-store")]
                 {
-                    let data_dir = crate::fs::data_dir(&wal_namespace);
+                    let data_dir = crate::fs::data_dir(&cluster_name);
                     // 1MB flush threshold
                     let flush_thresh = 4 * 1024 * 1024;
                     Box::new(
@@ -276,7 +275,7 @@ impl NodeBuilder {
             web_port,
             self.join_peer,
             self.cluster_config,
-            wal_namespace,
+            cluster_name,
         )));
 
         // Load static functions if provided

--- a/gossipgrid/src/node/state.rs
+++ b/gossipgrid/src/node/state.rs
@@ -111,7 +111,7 @@ impl NodeState {
         local_web_port: u16,
         seed_peer: Option<NodeAddress>,
         cluster_config: Option<cluster::Cluster>,
-        cluster_name: String,
+        join_cluster_name: String,
     ) -> NodeState {
         match (cluster_config, seed_peer) {
             (Some(cluster_config), None) => {
@@ -160,7 +160,7 @@ impl NodeState {
                     web_port: local_web_port,
                     peer_node: seed_peer,
                     cluster: cluster_config,
-                    cluster_name,
+                    cluster_name: join_cluster_name,
                     node_hlc: HLC {
                         timestamp: 0, // Initialize HLC with zero timestamp otherwise new node will be seen as source of truth for cluster state
                         counter: 0,

--- a/gossipgrid/src/node/state.rs
+++ b/gossipgrid/src/node/state.rs
@@ -46,6 +46,7 @@ pub struct PreJoinNode {
     pub web_port: u16,
     pub peer_node: NodeAddress,
     pub cluster: Option<Cluster>,
+    pub cluster_name: String,
     pub node_hlc: HLC,
 }
 
@@ -110,6 +111,7 @@ impl NodeState {
         local_web_port: u16,
         seed_peer: Option<NodeAddress>,
         cluster_config: Option<cluster::Cluster>,
+        cluster_name: String,
     ) -> NodeState {
         match (cluster_config, seed_peer) {
             (Some(cluster_config), None) => {
@@ -158,6 +160,7 @@ impl NodeState {
                     web_port: local_web_port,
                     peer_node: seed_peer,
                     cluster: cluster_config,
+                    cluster_name,
                     node_hlc: HLC {
                         timestamp: 0, // Initialize HLC with zero timestamp otherwise new node will be seen as source of truth for cluster state
                         counter: 0,

--- a/gossipgrid/src/store/sstable_store/mod.rs
+++ b/gossipgrid/src/store/sstable_store/mod.rs
@@ -50,7 +50,11 @@ impl SstableStore {
 
         if truncate && data_dir.exists() {
             if let Err(err) = fs::remove_dir_all(&data_dir) {
-                log::warn!("Failed to delete existing data directory {:?}: {}", data_dir, err);
+                log::warn!(
+                    "Failed to delete existing data directory {:?}: {}",
+                    data_dir,
+                    err
+                );
             }
         }
 

--- a/gossipgrid/tests/helpers/mod.rs
+++ b/gossipgrid/tests/helpers/mod.rs
@@ -118,6 +118,7 @@ pub async fn start_test_cluster_with_env(
         web_port,
         None,
         Some(cluster_config),
+        "test_cluser".to_string(),
     )));
 
     let node_memory_2 = Arc::new(RwLock::new(NodeState::init(
@@ -125,6 +126,7 @@ pub async fn start_test_cluster_with_env(
         web_port_2,
         Some(local_addr.clone()),
         None,
+        "test_cluser".to_string(),
     )));
 
     let node_memory_3 = Arc::new(RwLock::new(NodeState::init(
@@ -132,6 +134,7 @@ pub async fn start_test_cluster_with_env(
         web_port_3,
         Some(local_addr.clone()),
         None,
+        "test_cluser".to_string(),
     )));
 
     let node_1 = node::start_node(local_addr, web_port, node_memory_1.clone(), env1.clone()).await;


### PR DESCRIPTION
Prevent scenarios of ephemeral node or node using different cluster name attempting to join different named cluster